### PR TITLE
Update Readme to add select_browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ pacman -S mingw-w64-ucrt-x86_64-gtkmm-4.0
 git clone https://github.com/citkane/gtk-browser-widget.git
 cd gtk-browser-widget
 
-# Use the installer script
+# Use the installer script 
 source installer.sh
+set_browser mswebview2 # default is Chromium
 packages_install
 set_target examples/mswebview2/main.cc
 generate


### PR DESCRIPTION
The default browser is Chromium so the example in the Readme with mswebview2 will fail to compile. This adds a select_browser mswebview2 to the list of commands so the commands therein listed execute successfully.